### PR TITLE
DT-22 Decouple environ vars from lib

### DIFF
--- a/src/databrickstools/core.py
+++ b/src/databrickstools/core.py
@@ -10,7 +10,8 @@ from .settings import (
     DATABRICKSTOOLS_DEFAULT_LANGUAGE,
     DATABRICKSTOOLS_DEFAULT_FORMAT,
     DATABRICKSTOOLS_DATABRICKS_URL,
-    DATABRICKSTOOLS_LOG_LEVEL
+    DATABRICKSTOOLS_LOG_LEVEL,
+    databricks_environment_check
 )
 
 logger = logging.getLogger(__name__)
@@ -102,6 +103,7 @@ class ExportingCLI:
 class Main:
 
     def __init__(self):
+        databricks_environment_check()
         self.upload = ImportingCLI()
         self.download = ExportingCLI()
         self._directory_manager = DatabricksDirectoryManager(

--- a/src/databrickstools/databricks.py
+++ b/src/databrickstools/databricks.py
@@ -9,7 +9,7 @@ from .markdown import MarkdownFile
 from .settings import (
     DATABRICKSTOOLS_DEFAULT_FORMAT,
     DATABRICKSTOOLS_DEFAULT_LANGUAGE,
-    DATABRICKSTOOLS_DEFAULT_OVERWRITE_FLAG
+    DATABRICKSTOOLS_DEFAULT_OVERWRITE_FLAG,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/databrickstools/settings.py
+++ b/src/databrickstools/settings.py
@@ -8,15 +8,9 @@ DATABRICKSTOOLS_DATABRICKS_URL = os.environ.get(
     "DATABRICKSTOOLS_DATABRICKS_URL"
 )
 
-if DATABRICKSTOOLS_DATABRICKS_URL is None:
-    raise ValueError("Missing environment variable: DATABRICKSTOOLS_DATABRIKCS_URL")
-
 DATABRICKSTOOLS_DATABRICKS_TOKEN = os.environ.get(
     "DATABRICKSTOOLS_DATABRICKS_TOKEN"
 )
-
-if DATABRICKSTOOLS_DATABRICKS_TOKEN is None:
-    raise ValueError("Missing environment variable: DATABRICKSTOOLS_DATABRICKS_TOKEN")
 
 DATABRICKSTOOLS_LOG_LEVEL = os.environ.get(
     "DATABRICKSTOOLS_LOG_LEVEL",
@@ -43,3 +37,10 @@ DATABRICKSTOOLS_DEFAULT_FILE_ENDING = os.environ.get(
     "DATABRICKSTOOLS_DEFAULT_FILE_ENDING",
     default="Rmd"
 ).lower()
+
+
+def databricks_environment_check():
+    if DATABRICKSTOOLS_DATABRICKS_URL is None:
+        raise ValueError("Missing environment variable: DATABRICKSTOOLS_DATABRIKCS_URL")
+    if DATABRICKSTOOLS_DATABRICKS_TOKEN is None:
+        raise ValueError("Missing environment variable: DATABRICKSTOOLS_DATABRICKS_TOKEN")


### PR DESCRIPTION
## Description

This PR allows using some parts of the library without needing the definition of the databricks environment variables. 

Fixes #23 